### PR TITLE
Add basic auth and lead pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,12 +18,13 @@ import LeadDetails from './pages/LeadDetails';
 import Reports from './pages/Reports';
 import ReportDetails from './pages/ReportDetails';
 import AddContact from './pages/AddContact';
+import Profile from './pages/Profile';
 
 // Authentication pages
 import SignIn from './pages/auth/SignIn';
-import SignUp from './pages/auth/SignUp';
-import ForgotPassword from './pages/auth/ForgotPassword';
-import ResetPassword from './pages/auth/ResetPassword';
+
+import { AuthProvider } from './hooks/useAuth';
+import ProtectedRoute from './components/ProtectedRoute';
 
 // Component pages
 import ComponentAccordion from './pages/components/Accordion';
@@ -61,28 +62,56 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/contacts" element={<Contactus />} />
-          <Route path="/analytics" element={<Analytics />} />
-          <Route path="/messages" element={<Messages />} />
-          <Route path="/calendar" element={<Calendar />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/support" element={<Support />} />
-          <Route path="/deals" element={<Deals />} />
-          <Route path="/deal-details" element={<DealDetails />} />
-          <Route path="/leads" element={<Leads />} />
-          <Route path="/lead-details" element={<LeadDetails />} />
-          <Route path="/reports" element={<Reports />} />
-          <Route path="/report-details" element={<ReportDetails />} />
-          <Route path="/add-contact" element={<AddContact />} />
+      <AuthProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/auth/signin" element={<SignIn />} />
+            <Route
+              path="/"
+              element={
+                <ProtectedRoute>
+                  <Index />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/contacts"
+              element={
+                <ProtectedRoute>
+                  <Contactus />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/analytics"
+              element={
+                <ProtectedRoute>
+                  <Analytics />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/messages"
+              element={
+                <ProtectedRoute>
+                  <Messages />
+                </ProtectedRoute>
+              }
+            />
+            <Route path="/calendar" element={<ProtectedRoute><Calendar /></ProtectedRoute>} />
+            <Route path="/settings" element={<ProtectedRoute><Settings /></ProtectedRoute>} />
+            <Route path="/support" element={<ProtectedRoute><Support /></ProtectedRoute>} />
+            <Route path="/deals" element={<ProtectedRoute><Deals /></ProtectedRoute>} />
+            <Route path="/deal-details" element={<ProtectedRoute><DealDetails /></ProtectedRoute>} />
+            <Route path="/leads" element={<ProtectedRoute><Leads /></ProtectedRoute>} />
+            <Route path="/lead-details/:id?" element={<ProtectedRoute><LeadDetails /></ProtectedRoute>} />
+            <Route path="/reports" element={<ProtectedRoute><Reports /></ProtectedRoute>} />
+            <Route path="/report-details" element={<ProtectedRoute><ReportDetails /></ProtectedRoute>} />
+            <Route path="/add-contact" element={<ProtectedRoute><AddContact /></ProtectedRoute>} />
+            <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
           
           {/* Authentication routes */}
-          <Route path="/auth/signin" element={<SignIn />} />
-          <Route path="/auth/signup" element={<SignUp />} />
-          <Route path="/auth/forgot-password" element={<ForgotPassword />} />
-          <Route path="/auth/reset-password" element={<ResetPassword />} />
+            <Route path="/auth/signin" element={<SignIn />} />
           
           {/* Component routes */}
           <Route path="/components/accordion" element={<ComponentAccordion />} />
@@ -116,6 +145,7 @@ const App = () => (
           <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>
+      </AuthProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import Reports from './pages/Reports';
 import ReportDetails from './pages/ReportDetails';
 import AddContact from './pages/AddContact';
 import Profile from './pages/Profile';
+import RoleAccess from './pages/RoleAccess';
 
 // Authentication pages
 import SignIn from './pages/auth/SignIn';
@@ -109,6 +110,7 @@ const App = () => (
             <Route path="/report-details" element={<ProtectedRoute><ReportDetails /></ProtectedRoute>} />
             <Route path="/add-contact" element={<ProtectedRoute><AddContact /></ProtectedRoute>} />
             <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
+            <Route path="/role-access" element={<ProtectedRoute><RoleAccess /></ProtectedRoute>} />
           
           {/* Authentication routes */}
             <Route path="/auth/signin" element={<SignIn />} />

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,8 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function ProtectedRoute({ children }: { children: JSX.Element }) {
+  const { user } = useAuth();
+  if (!user) return <Navigate to="/auth/signin" replace />;
+  return children;
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,13 +5,22 @@ import { ThemeToggle } from '@/components/ui/ThemeToggle';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
 interface HeaderProps {
   toggleSidebar: () => void;
   openSettings: () => void;
 }
 
 export function Header({ toggleSidebar, openSettings }: HeaderProps) {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/auth/signin');
+  };
+
   return (
     <header className="sticky top-0 z-30 bg-background border-b border-border h-16 flex items-center px-4 md:px-6 shadow-sm">
       <div className="flex items-center gap-2 md:gap-4 w-full">
@@ -57,11 +66,14 @@ export function Header({ toggleSidebar, openSettings }: HeaderProps) {
             <DropdownMenuContent className="w-56" align="end" forceMount>
               <DropdownMenuLabel>My Account</DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <DropdownMenuItem>Profile</DropdownMenuItem>
-              <DropdownMenuItem>Settings</DropdownMenuItem>
-              <DropdownMenuItem>Billing</DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link to="/profile">Profile</Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link to="/settings">Settings</Link>
+              </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem>Log out</DropdownMenuItem>
+              <DropdownMenuItem onClick={handleLogout}>Log out</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -212,6 +212,7 @@ export function Sidebar({ isOpen, toggleSidebar }: SidebarProps) {
         {/* Fixed Footer */}
         <div className="border-t border-border p-2 flex-shrink-0">
           <nav className="grid gap-1">
+            <NavItem icon={KeyRound} label="Role Access" href="/role-access" isCollapsed={isCollapsed} />
             <NavItem icon={Settings} label="Settings" href="/settings" isCollapsed={isCollapsed} />
             <NavItem icon={LifeBuoy} label="Support" href="/support" isCollapsed={isCollapsed} />
             <Button

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -166,9 +166,6 @@ export function Sidebar({ isOpen, toggleSidebar }: SidebarProps) {
 
             <nav className="grid gap-1">
               <NavItem icon={Lock} label="Sign In" href="/auth/signin" isCollapsed={isCollapsed} />
-              <NavItem icon={UserCheck} label="Sign Up" href="/auth/signup" isCollapsed={isCollapsed} />
-              <NavItem icon={KeyRound} label="Forgot Password" href="/auth/forgot-password" isCollapsed={isCollapsed} />
-              <NavItem icon={RotateCcw} label="Reset Password" href="/auth/reset-password" isCollapsed={isCollapsed} />
             </nav>
 
             <Separator className="my-4" />

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -32,7 +32,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const login = async (email: string, password: string) => {
-    const res = await fetch("/login", {
+    const res = await fetch("http://localhost:3001/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email, password })
@@ -60,7 +60,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const refreshUser = async () => {
     if (!token) return;
-    const res = await fetchWithAuth("/me");
+    const res = await fetchWithAuth("http://localhost:3001/me");
     if (res.ok) {
       const data = await res.json();
       setUser(data);

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,0 +1,82 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+interface User {
+  userid: number;
+  name: string;
+  email: string;
+  roleid: number;
+}
+
+interface AuthContextType {
+  user: User | null;
+  token: string | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+  fetchWithAuth: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+  refreshUser: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("auth");
+    if (stored) {
+      const { user, token } = JSON.parse(stored);
+      setUser(user);
+      setToken(token);
+    }
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    const res = await fetch("/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password })
+    });
+    if (!res.ok) {
+      throw new Error("Invalid credentials");
+    }
+    const data = await res.json();
+    setUser(data.user);
+    setToken(data.token);
+    localStorage.setItem("auth", JSON.stringify({ user: data.user, token: data.token }));
+  };
+
+  const logout = () => {
+    setUser(null);
+    setToken(null);
+    localStorage.removeItem("auth");
+  };
+
+  const fetchWithAuth = (input: RequestInfo, init: RequestInit = {}) => {
+    const headers = new Headers(init.headers);
+    if (token) headers.set("Authorization", `Bearer ${token}`);
+    return fetch(input, { ...init, headers });
+  };
+
+  const refreshUser = async () => {
+    if (!token) return;
+    const res = await fetchWithAuth("/me");
+    if (res.ok) {
+      const data = await res.json();
+      setUser(data);
+      localStorage.setItem("auth", JSON.stringify({ user: data, token }));
+    }
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, token, login, logout, fetchWithAuth, refreshUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/src/pages/LeadDetails.tsx
+++ b/src/pages/LeadDetails.tsx
@@ -96,11 +96,11 @@ export default function LeadDetails() {
   const editMode = !!id;
 
   useEffect(() => {
-    fetchWithAuth('/columns')
+    fetchWithAuth('http://localhost:3001/columns')
       .then(res => res.json())
       .then((data: { title: string }[]) => setStatuses(data.map(c => c.title)));
 
-    fetchWithAuth('/assignable-users')
+    fetchWithAuth('http://localhost:3001/assignable-users')
       .then(res => res.json())
       .then((data: any[]) => {
         const list = [...data];
@@ -111,7 +111,7 @@ export default function LeadDetails() {
       });
 
     if (editMode) {
-      fetchWithAuth(`/crm-leads/${id}`)
+      fetchWithAuth(`http://localhost:3001/crm-leads/${id}`)
         .then(res => res.json())
         .then(data => {
           if (data.assignedto) {
@@ -144,7 +144,8 @@ export default function LeadDetails() {
           legalnamessn: data.legalnamessn || data.legalNameSsn || "",
           last4ssn: data.last4ssn || data.last4Ssn || ""
         });
-    }
+    });
+  }
   }, [id, user, editMode, fetchWithAuth]);
 
   const addChecklistItem = () => {
@@ -184,7 +185,7 @@ export default function LeadDetails() {
     e.preventDefault();
     setError(null);
     if (!editMode) {
-      const existing = await fetchWithAuth('/crm-leads').then(r => r.json());
+      const existing = await fetchWithAuth('http://localhost:3001/crm-leads').then(r => r.json());
       if (existing.some((l: any) => l.email === form.email)) {
         setError('Lead with this email or phone already exists');
         return;
@@ -211,7 +212,7 @@ export default function LeadDetails() {
     };
 
     const method = editMode ? 'PUT' : 'POST';
-    const url = editMode ? `/crm-leads/${id}` : '/crm-leads';
+    const url = editMode ? `http://localhost:3001/crm-leads/${id}` : 'http://localhost:3001/crm-leads';
     const res = await fetchWithAuth(url, {
       method,
       headers: { 'Content-Type': 'application/json' },

--- a/src/pages/LeadDetails.tsx
+++ b/src/pages/LeadDetails.tsx
@@ -1,15 +1,94 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { DashboardLayout } from "@/components/layout/DashboardLayout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { ArrowLeft } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
 
-import { DashboardLayout } from '@/components/layout/DashboardLayout';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { ArrowLeft, Save, Star } from 'lucide-react';
-import { Link } from 'react-router-dom';
+interface LeadForm {
+  firstname: string;
+  lastname: string;
+  email: string;
+  phone?: string;
+  company: string;
+  status: string;
+  source?: string;
+  notes?: string;
+  assignedto?: string;
+}
 
-const LeadDetails = () => {
+export default function LeadDetails() {
+  const { id } = useParams<{ id: string }>();
+  const { fetchWithAuth } = useAuth();
+  const navigate = useNavigate();
+  const [form, setForm] = useState<LeadForm>({
+    firstname: "",
+    lastname: "",
+    email: "",
+    phone: "",
+    company: "",
+    status: "new",
+    source: "",
+    notes: "",
+    assignedto: ""
+  });
+  const [error, setError] = useState<string | null>(null);
+  const editMode = !!id;
+
+  useEffect(() => {
+    if (editMode) {
+      fetchWithAuth(`/crm-leads/${id}`)
+        .then(res => res.json())
+        .then(data => setForm({
+          firstname: data.firstname,
+          lastname: data.lastname,
+          email: data.email,
+          phone: data.phone || "",
+          company: data.company,
+          status: data.status,
+          source: data.source || "",
+          notes: data.notes || "",
+          assignedto: data.assignedto || ""
+        }));
+    }
+  }, [id]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const saveLead = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!editMode) {
+      const existing = await fetchWithAuth('/crm-leads').then(r => r.json());
+      if (existing.some((l: any) => l.email === form.email || (form.phone && l.phone === form.phone))) {
+        setError('Lead with this email or phone already exists');
+        return;
+      }
+    }
+    const method = editMode ? 'PUT' : 'POST';
+    const url = editMode ? `/crm-leads/${id}` : '/crm-leads';
+    const res = await fetchWithAuth(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    });
+    if (res.ok) {
+      navigate('/leads');
+    } else {
+      const data = await res.json();
+      setError(data.message || 'Error saving lead');
+    }
+  };
+
+  const stageFields = form.status === 'qualified';
+
   return (
     <DashboardLayout>
       <div className="space-y-6">
@@ -20,175 +99,66 @@ const LeadDetails = () => {
             </Link>
           </Button>
           <div>
-            <h1 className="text-3xl font-bold tracking-tight">Lead Details</h1>
-            <p className="text-muted-foreground">Create or edit lead information</p>
+            <h1 className="text-3xl font-bold tracking-tight">{editMode ? 'Edit Lead' : 'New Lead'}</h1>
           </div>
         </div>
 
-        <div className="grid gap-6 lg:grid-cols-3">
-          <div className="lg:col-span-2 space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Contact Information</CardTitle>
-                <CardDescription>Enter the basic contact details</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="firstName">First Name</Label>
-                    <Input id="firstName" placeholder="First name" />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="lastName">Last Name</Label>
-                    <Input id="lastName" placeholder="Last name" />
-                  </div>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="email">Email</Label>
-                    <Input id="email" type="email" placeholder="email@example.com" />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="phone">Phone</Label>
-                    <Input id="phone" placeholder="Phone number" />
-                  </div>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="company">Company</Label>
-                    <Input id="company" placeholder="Company name" />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="jobTitle">Job Title</Label>
-                    <Input id="jobTitle" placeholder="Job title" />
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle>Lead Information</CardTitle>
-                <CardDescription>Lead qualification and source details</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="grid grid-cols-3 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="status">Status</Label>
-                    <Select>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select status" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="new">New</SelectItem>
-                        <SelectItem value="contacted">Contacted</SelectItem>
-                        <SelectItem value="qualified">Qualified</SelectItem>
-                        <SelectItem value="unqualified">Unqualified</SelectItem>
-                        <SelectItem value="converted">Converted</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="source">Source</Label>
-                    <Select>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select source" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="website">Website</SelectItem>
-                        <SelectItem value="linkedin">LinkedIn</SelectItem>
-                        <SelectItem value="referral">Referral</SelectItem>
-                        <SelectItem value="event">Event</SelectItem>
-                        <SelectItem value="cold-call">Cold Call</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="score">Lead Score</Label>
-                    <Input id="score" type="number" min="0" max="100" placeholder="85" />
-                  </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Lead Information</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-4" onSubmit={saveLead}>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="firstname">First Name</Label>
+                  <Input id="firstname" name="firstname" value={form.firstname} onChange={handleChange} required />
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="owner">Lead Owner</Label>
-                  <Select>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select owner" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="john">John Smith</SelectItem>
-                      <SelectItem value="sarah">Sarah Johnson</SelectItem>
-                      <SelectItem value="mike">Mike Wilson</SelectItem>
-                    </SelectContent>
-                  </Select>
+                  <Label htmlFor="lastname">Last Name</Label>
+                  <Input id="lastname" name="lastname" value={form.lastname} onChange={handleChange} required />
                 </div>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="email">Email</Label>
+                  <Input id="email" name="email" type="email" value={form.email} onChange={handleChange} required />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="phone">Phone</Label>
+                  <Input id="phone" name="phone" value={form.phone} onChange={handleChange} />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="company">Company</Label>
+                <Input id="company" name="company" value={form.company} onChange={handleChange} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="status">Status</Label>
+                <Select value={form.status} onValueChange={(v) => setForm({ ...form, status: v })}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="new">New</SelectItem>
+                    <SelectItem value="contacted">Contacted</SelectItem>
+                    <SelectItem value="qualified">Qualified</SelectItem>
+                    <SelectItem value="unqualified">Unqualified</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              {stageFields && (
                 <div className="space-y-2">
                   <Label htmlFor="notes">Notes</Label>
-                  <Textarea id="notes" placeholder="Lead notes and comments" rows={4} />
+                  <Textarea id="notes" name="notes" value={form.notes} onChange={handleChange} />
                 </div>
-              </CardContent>
-            </Card>
-          </div>
-
-          <div className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle>Actions</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                <Button className="w-full">
-                  <Save className="mr-2 h-4 w-4" />
-                  Save Lead
-                </Button>
-                <Button variant="outline" className="w-full">
-                  Convert to Deal
-                </Button>
-                <Button variant="outline" className="w-full">
-                  Schedule Follow-up
-                </Button>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle>Lead Score</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="flex items-center space-x-2">
-                  <Star className="h-8 w-8 text-yellow-400 fill-current" />
-                  <div>
-                    <div className="text-2xl font-bold">85/100</div>
-                    <p className="text-sm text-muted-foreground">High Quality Lead</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle>Lead Summary</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="text-sm space-y-2">
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Created:</span>
-                    <span>Today</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Last Contact:</span>
-                    <span>Never</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Activities:</span>
-                    <span>0</span>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
+              )}
+              {error && <p className="text-sm text-red-600">{error}</p>}
+              <Button type="submit">Save</Button>
+            </form>
+          </CardContent>
+        </Card>
       </div>
     </DashboardLayout>
   );
-};
-
-export default LeadDetails;
+}

--- a/src/pages/LeadDetails.tsx
+++ b/src/pages/LeadDetails.tsx
@@ -99,6 +99,7 @@ export default function LeadDetails() {
     fetchWithAuth('/columns')
       .then(res => res.json())
       .then((data: { title: string }[]) => setStatuses(data.map(c => c.title)));
+
     fetchWithAuth('/assignable-users')
       .then(res => res.json())
       .then((data: any[]) => {
@@ -113,16 +114,20 @@ export default function LeadDetails() {
       fetchWithAuth(`/crm-leads/${id}`)
         .then(res => res.json())
         .then(data => {
-          if (data.assignedto && !assignable.some(u => String(u.userid) === String(data.assignedto))) {
+          if (data.assignedto) {
             const uid = Number(data.assignedto);
-            const newList = [...assignable, { userid: uid, name: `User ${uid}` }];
-            setAssignable(newList);
+            setAssignable(prev => {
+              if (!prev.some(u => u.userid === uid)) {
+                return [...prev, { userid: uid, name: `User ${uid}` }];
+              }
+              return prev;
+            });
           }
           setForm({
-           firstname: data.firstname,
-          lastname: data.lastname,
-          email: data.email,
-          phone: data.phone || "",
+            firstname: data.firstname,
+            lastname: data.lastname,
+            email: data.email,
+            phone: data.phone || "",
           company: data.company,
           status: data.status,
           source: data.source || "",
@@ -140,7 +145,7 @@ export default function LeadDetails() {
           last4ssn: data.last4ssn || data.last4Ssn || ""
         });
     }
-  }, [id, user]);
+  }, [id, user, editMode, fetchWithAuth]);
 
   const addChecklistItem = () => {
     setForm({ ...form, checklist: [...form.checklist, { label: "", checked: false }] });

--- a/src/pages/Leads.tsx
+++ b/src/pages/Leads.tsx
@@ -28,7 +28,7 @@ const Leads = () => {
   const [userMap, setUserMap] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    fetchWithAuth('/assignable-users')
+    fetchWithAuth('http://localhost:3001/assignable-users')
       .then(res => res.json())
       .then(data => {
         const map: Record<string, string> = {};
@@ -36,7 +36,7 @@ const Leads = () => {
         data.forEach((u: any) => { map[String(u.userid)] = u.name; });
         setUserMap(map);
       });
-    fetchWithAuth('/crm-leads')
+    fetchWithAuth('http://localhost:3001/crm-leads')
       .then(res => res.json())
       .then(data => setLeads(data));
   }, [user]);

--- a/src/pages/Leads.tsx
+++ b/src/pages/Leads.tsx
@@ -167,15 +167,25 @@ const Leads = () => {
                 {paginatedLeads.map((lead) => (
                   <div key={lead.id} className="p-4 border rounded-lg hover:bg-muted/50 transition-colors">
                     <div className="flex-1 space-y-1">
-                      <div className="flex items-center justify-between">
-                        <h3 className="font-semibold">{lead.firstname} {lead.lastname}</h3>
-                        <Link to={`/lead-details/${lead.id}`} className="text-sm text-primary underline">Edit</Link>
+                      <div className="flex items-center justify-between gap-2">
+                        <h3 className="font-semibold truncate">
+                          {lead.firstname} {lead.lastname}
+                        </h3>
+                        <Badge variant="secondary" className="ml-auto">
+                          {lead.company}
+                        </Badge>
+                        <Link
+                          to={`/lead-details/${lead.id}`}
+                          className="text-sm text-primary underline"
+                        >
+                          Edit
+                        </Link>
                       </div>
                       <div className="flex gap-4 text-sm text-muted-foreground">
                         <span>{lead.email}</span>
                         {lead.phone && <span>{lead.phone}</span>}
                       </div>
-                      <p className="text-sm text-muted-foreground">{lead.company}</p>
+
                       <div className="flex flex-wrap items-center gap-2 mt-2">
                         <Badge className={getStatusColor(lead.status)}>
                           {lead.status.charAt(0).toUpperCase() + lead.status.slice(1)}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { DashboardLayout } from "@/components/layout/DashboardLayout";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function Profile() {
+  const { user, fetchWithAuth, refreshUser } = useAuth();
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    refreshUser();
+  }, []);
+
+  const changePassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage(null);
+    const res = await fetchWithAuth("/change-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ currentPassword, newPassword })
+    });
+    if (res.ok) {
+      setMessage("Password updated");
+      setCurrentPassword("");
+      setNewPassword("");
+    } else {
+      const data = await res.json();
+      setMessage(data.message || "Error updating password");
+    }
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold tracking-tight">Profile</h1>
+        {user && (
+          <Card>
+            <CardHeader>
+              <CardTitle>User Info</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <div>
+                <Label>Name</Label>
+                <Input value={user.name} readOnly />
+              </div>
+              <div>
+                <Label>Email</Label>
+                <Input value={user.email} readOnly />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Change Password</CardTitle>
+            <CardDescription>Update your account password</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-4" onSubmit={changePassword}>
+              <div>
+                <Label htmlFor="current">Current Password</Label>
+                <Input id="current" type="password" value={currentPassword} onChange={e => setCurrentPassword(e.target.value)} required />
+              </div>
+              <div>
+                <Label htmlFor="new">New Password</Label>
+                <Input id="new" type="password" value={newPassword} onChange={e => setNewPassword(e.target.value)} required />
+              </div>
+              {message && <p className="text-sm text-muted-foreground">{message}</p>}
+              <Button type="submit">Update Password</Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -19,7 +19,7 @@ export default function Profile() {
   const changePassword = async (e: React.FormEvent) => {
     e.preventDefault();
     setMessage(null);
-    const res = await fetchWithAuth("/change-password", {
+    const res = await fetchWithAuth("http://localhost:3001/change-password", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ currentPassword, newPassword })

--- a/src/pages/RoleAccess.tsx
+++ b/src/pages/RoleAccess.tsx
@@ -1,0 +1,101 @@
+import { useState, useEffect } from 'react';
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/hooks/useAuth';
+
+const components = [
+  { id: 'dashboard', name: 'Dashboard' },
+  { id: 'contacts', name: 'Contacts' },
+  { id: 'deals', name: 'Deals' },
+  { id: 'leads', name: 'Leads' },
+  { id: 'reports', name: 'Reports' },
+  { id: 'settings', name: 'Settings' }
+];
+
+export default function RoleAccess() {
+  const { toast } = useToast();
+  const { fetchWithAuth } = useAuth();
+  const [roles, setRoles] = useState<string[]>([]);
+  const [permissions, setPermissions] = useState<Record<string, Record<string, boolean>>>({});
+
+  useEffect(() => {
+    fetchWithAuth('http://localhost:3001/roles')
+      .then(res => res.json())
+      .then((data: any[]) => setRoles(data.map(r => r.name)))
+      .catch(() => toast({ title: 'Failed to load roles', variant: 'destructive' }));
+
+    fetchWithAuth('http://localhost:3001/role-access')
+      .then(res => res.json())
+      .then(data => setPermissions(data))
+      .catch(() => toast({ title: 'Failed to load permissions', variant: 'destructive' }));
+  }, [fetchWithAuth, toast]);
+
+  const togglePermission = (componentId: string, role: string) => {
+    setPermissions(prev => ({
+      ...prev,
+      [componentId]: {
+        ...prev[componentId],
+        [role]: !prev?.[componentId]?.[role]
+      }
+    }));
+  };
+
+  const handleSave = async () => {
+    const res = await fetchWithAuth('http://localhost:3001/role-access', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(permissions)
+    });
+    if (res.ok) {
+      toast({ title: 'Permissions updated' });
+    } else {
+      const data = await res.json().catch(() => ({}));
+      toast({ title: data.message || 'Error updating permissions', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold tracking-tight">Role Access</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle>Component Access by Role</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Component</TableHead>
+                  {roles.map(role => (
+                    <TableHead key={role} className="text-center">{role}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {components.map(comp => (
+                  <TableRow key={comp.id}>
+                    <TableCell className="font-medium">{comp.name}</TableCell>
+                    {roles.map(role => (
+                      <TableCell key={role} className="text-center">
+                        <Checkbox
+                          checked={permissions?.[comp.id]?.[role] ?? false}
+                          onCheckedChange={() => togglePermission(comp.id, role)}
+                        />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+        <Button onClick={handleSave}>Save</Button>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/pages/auth/SignIn.tsx
+++ b/src/pages/auth/SignIn.tsx
@@ -1,23 +1,29 @@
 
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Eye, EyeOff, Mail, Lock } from 'lucide-react';
+import { useAuth } from '@/hooks/useAuth';
 
 export default function SignIn() {
+  const { login, user } = useAuth();
   const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [formData, setFormData] = useState({
     email: '',
     password: ''
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // Handle sign in logic here
-    console.log('Sign in attempt:', formData);
+    try {
+      await login(formData.email, formData.password);
+    } catch (err) {
+      setError('Invalid email or password');
+    }
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -26,6 +32,8 @@ export default function SignIn() {
       [e.target.name]: e.target.value
     });
   };
+
+  if (user) return <Navigate to="/" />;
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
@@ -90,25 +98,12 @@ export default function SignIn() {
               </div>
             </div>
 
-            <div className="flex items-center justify-between">
-              <Link
-                to="/auth/forgot-password"
-                className="text-sm text-primary hover:underline"
-              >
-                Forgot password?
-              </Link>
-            </div>
+            {error && <p className="text-sm text-red-600">{error}</p>}
 
             <Button type="submit" className="w-full">
               Sign In
             </Button>
 
-            <div className="text-center text-sm">
-              Don't have an account?{' '}
-              <Link to="/auth/signup" className="text-primary hover:underline">
-                Sign up
-              </Link>
-            </div>
           </form>
         </CardContent>
       </Card>

--- a/src/pages/components/Sortable.tsx
+++ b/src/pages/components/Sortable.tsx
@@ -4,7 +4,23 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useState } from 'react';
-import { GripVertical, User, Star, Calendar, Mail, Settings } from 'lucide-react';
+import {
+  GripVertical,
+  User,
+  Star,
+  Calendar,
+  Mail,
+  Settings,
+  MoreVertical,
+  Pencil,
+  Trash2,
+} from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 
 interface SortableItem {
@@ -130,6 +146,21 @@ export default function ComponentSortable() {
                       {index + 1}
                     </span>
                     <span className="flex-1">{item.title}</span>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" size="icon">
+                          <MoreVertical className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent>
+                        <DropdownMenuItem>
+                          <Pencil className="h-4 w-4 mr-2" /> Edit
+                        </DropdownMenuItem>
+                        <DropdownMenuItem>
+                          <Trash2 className="h-4 w-4 mr-2" /> Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </div>
                 ))}
               </div>
@@ -185,6 +216,21 @@ export default function ComponentSortable() {
                       <span className="bg-muted text-muted-foreground w-6 h-6 rounded-full flex items-center justify-center text-xs font-medium flex-shrink-0">
                         {index + 1}
                       </span>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon">
+                            <MoreVertical className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent>
+                          <DropdownMenuItem>
+                            <Pencil className="h-4 w-4 mr-2" /> Edit
+                          </DropdownMenuItem>
+                          <DropdownMenuItem>
+                            <Trash2 className="h-4 w-4 mr-2" /> Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </div>
                   );
                 })}


### PR DESCRIPTION
## Summary
- implement auth provider and protected route
- integrate login with backend token issuance
- add profile page with password change
- fetch leads from API and link to lead detail page
- support creating and editing leads with duplicate check
- simplify sidebar and header for authenticated flow

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68565f921e908329953d3cd65d53fae6