### PR TITLE
Implement loading overlays on data pages

### DIFF
--- a/src/components/ui/loading-overlay.tsx
+++ b/src/components/ui/loading-overlay.tsx
@@ -1,0 +1,10 @@
+import { Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export function LoadingOverlay({ className }: { className?: string }) {
+  return (
+    <div className={cn('absolute inset-0 flex items-center justify-center bg-background/80 backdrop-blur-sm z-50', className)}>
+      <Loader2 className="h-8 w-8 animate-spin text-primary" />
+    </div>
+  );
+}

--- a/src/pages/Leads.tsx
+++ b/src/pages/Leads.tsx
@@ -1,5 +1,6 @@
 
 import { useEffect, useState } from 'react';
+import { LoadingOverlay } from '@/components/ui/loading-overlay';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -41,22 +42,26 @@ const Leads = () => {
   const [leads, setLeads] = useState<Lead[]>([]);
   const [userMap, setUserMap] = useState<Record<string, string>>({});
   const [currentPage, setCurrentPage] = useState(1);
+  const [loading, setLoading] = useState(true);
   const leadsPerPage = 10;
 
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
   useEffect(() => {
-    fetchWithAuth(`${API_BASE_URL}/assignable-users`)
-      .then(res => res.json())
-      .then(data => {
-        const map: Record<string, string> = {};
-        if (user) map[String(user.userid)] = user.name;
-        data.forEach((u: any) => { map[String(u.userid)] = u.name; });
-        setUserMap(map);
-      });
-    fetchWithAuth(`${API_BASE_URL}/crm-leads`)
-      .then(res => res.json())
-      .then(data => setLeads(data));
+    setLoading(true);
+    Promise.all([
+      fetchWithAuth(`${API_BASE_URL}/assignable-users`)
+        .then(res => res.json())
+        .then(data => {
+          const map: Record<string, string> = {};
+          if (user) map[String(user.userid)] = user.name;
+          data.forEach((u: any) => { map[String(u.userid)] = u.name; });
+          setUserMap(map);
+        }),
+      fetchWithAuth(`${API_BASE_URL}/crm-leads`)
+        .then(res => res.json())
+        .then(data => setLeads(data))
+    ]).finally(() => setLoading(false));
   }, [user]);
 
   useEffect(() => {
@@ -91,7 +96,10 @@ const Leads = () => {
 
   return (
     <DashboardLayout>
-      <div className="space-y-6">
+      <div className="relative min-h-[200px]">
+        {loading && <LoadingOverlay />}
+        {!loading && (
+          <div className="space-y-6">
         <div className="flex justify-between items-center">
           <div>
             <h1 className="text-3xl font-bold tracking-tight">Leads</h1>
@@ -220,6 +228,8 @@ const Leads = () => {
             </div>
           </CardContent>
         </Card>
+      </div>
+        )}
       </div>
     </DashboardLayout>
   );


### PR DESCRIPTION
## Summary
- add `LoadingOverlay` component
- show loading overlays in Leads, LeadDetails and RoleAccess pages while fetching data

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68573fc7533883299363475f915af55e