### PR TITLE
Add token refresh to auth hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ VITE_API_BASE_URL=http://localhost:3001
 
 All API requests use this variable.
 
+## Token Refresh Behavior
+
+The `AuthProvider` stores both an access token and refresh token after a
+successful login. The application expects your backend to expose a `POST
+/refresh` endpoint that accepts the stored refresh token and returns a new pair
+of tokens.
+
+When any authenticated request returns `401`, `fetchWithAuth` will call
+`refreshToken()` and retry the original request once. If refreshing also fails
+with `401`, the user is logged out and local storage is cleared.
+
+Ensure your backend implements `/refresh` for this workflow to succeed.
+
 ## What technologies are used for this project?
 
 This project is built with:

--- a/src/pages/components/Dropdown.tsx
+++ b/src/pages/components/Dropdown.tsx
@@ -37,12 +37,21 @@ import {
   Github
 } from 'lucide-react';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
 
 export default function ComponentDropdown() {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
   const [position, setPosition] = useState("bottom");
   const [showStatusBar, setShowStatusBar] = useState(true);
   const [showActivityBar, setShowActivityBar] = useState(false);
   const [showPanel, setShowPanel] = useState(false);
+
+  const handleLogout = () => {
+    logout();
+    navigate('/auth/signin');
+  };
 
   return (
     <DashboardLayout>
@@ -147,7 +156,7 @@ export default function ComponentDropdown() {
                       <DropdownMenuShortcut>⌘K</DropdownMenuShortcut>
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
-                    <DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleLogout}>
                       <LogOut className="mr-2 h-4 w-4" />
                       <span>Log out</span>
                       <DropdownMenuShortcut>⇧⌘Q</DropdownMenuShortcut>


### PR DESCRIPTION
## Summary
- add automatic token refresh logic and store refresh token
- hook up logout in Dropdown demo
- document refresh token endpoint behavior

## Testing
- `npm run lint` *(fails: 14 errors, 15 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_685755e166588329903d03225ae18569