### PR TITLE
Update user management and sign-in pages

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -14,9 +14,19 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { User, Bell, Shield, Palette, Globe, Database, Key } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/hooks/useAuth';
+
+const roleMap: Record<number, string> = {
+  1: 'Super Admin',
+  2: 'Admin',
+  3: 'Manager',
+  4: 'Lead',
+  5: 'Agent'
+};
 
 const Settings = () => {
   const { toast } = useToast();
+  const { user, refreshUser } = useAuth();
   const [profile, setProfile] = useState({
     firstName: 'John',
     lastName: 'Doe',
@@ -43,6 +53,23 @@ const Settings = () => {
     dateFormat: 'MM/DD/YYYY',
     currency: 'USD'
   });
+
+  useEffect(() => {
+    refreshUser();
+  }, [refreshUser]);
+
+  useEffect(() => {
+    if (user) {
+      const [first = '', ...rest] = user.name.split(' ');
+      setProfile(prev => ({
+        ...prev,
+        firstName: first,
+        lastName: rest.join(' '),
+        email: user.email,
+        position: roleMap[user.roleid] || prev.position
+      }));
+    }
+  }, [user]);
 
   const handleSaveProfile = () => {
     toast({

--- a/src/pages/UserManagement.tsx
+++ b/src/pages/UserManagement.tsx
@@ -30,9 +30,10 @@ export default function UserManagement() {
   const { toast } = useToast();
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
   const [users, setUsers] = useState<User[]>([]);
+  const [managers, setManagers] = useState<User[]>([]);
   const [roles, setRoles] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
-  const [form, setForm] = useState({ name: '', email: '', role: '', password: '' });
+  const [form, setForm] = useState({ name: '', email: '', role: '', managerId: '', password: '' });
   const [pwUser, setPwUser] = useState<User | null>(null);
   const [newPassword, setNewPassword] = useState('');
 
@@ -41,7 +42,12 @@ export default function UserManagement() {
   useEffect(() => {
     setLoading(true);
     Promise.all([
-      fetchWithAuth(`${API_BASE_URL}/users`).then(res => res.json()).then(setUsers),
+      fetchWithAuth(`${API_BASE_URL}/users`)
+        .then(res => res.json())
+        .then((data: User[]) => {
+          setUsers(data);
+          setManagers(data.filter(u => u.role.toLowerCase() === 'manager'));
+        }),
       fetchWithAuth(`${API_BASE_URL}/roles`).then(res => res.json()).then((data: any[]) => setRoles(data.map(r => r.name)))
     ]).finally(() => setLoading(false));
   }, [fetchWithAuth]);
@@ -62,7 +68,7 @@ export default function UserManagement() {
     if (res.ok) {
       const data = await res.json();
       setUsers(prev => [...prev, data]);
-      setForm({ name: '', email: '', role: '', password: '' });
+      setForm({ name: '', email: '', role: '', managerId: '', password: '' });
       toast({ title: 'User created' });
     } else {
       const data = await res.json().catch(() => ({}));
@@ -118,6 +124,19 @@ export default function UserManagement() {
                       <SelectContent>
                         {allowedRoles.map(r => (
                           <SelectItem key={r} value={r}>{r}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="manager">Manager</Label>
+                    <Select value={form.managerId} onValueChange={value => setForm({ ...form, managerId: value })}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select manager" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {managers.map(m => (
+                          <SelectItem key={m.userid} value={String(m.userid)}>{m.name}</SelectItem>
                         ))}
                       </SelectContent>
                     </Select>

--- a/src/pages/auth/SignIn.tsx
+++ b/src/pages/auth/SignIn.tsx
@@ -7,11 +7,13 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Eye, EyeOff, Mail, Lock } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
+import { LoadingOverlay } from '@/components/ui/loading-overlay';
 
 export default function SignIn() {
   const { login, user } = useAuth();
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
   const [formData, setFormData] = useState({
     email: '',
     password: ''
@@ -20,9 +22,12 @@ export default function SignIn() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
+      setLoading(true);
       await login(formData.email, formData.password);
     } catch (err) {
       setError('Invalid email or password');
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -36,7 +41,8 @@ export default function SignIn() {
   if (user) return <Navigate to="/" />;
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+    <div className="min-h-screen flex items-center justify-center bg-background p-4 relative">
+      {loading && <LoadingOverlay />}
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
           <div className="flex items-center justify-center mb-4">
@@ -100,8 +106,8 @@ export default function SignIn() {
 
             {error && <p className="text-sm text-red-600">{error}</p>}
 
-            <Button type="submit" className="w-full">
-              Sign In
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? 'Signing In...' : 'Sign In'}
             </Button>
 
           </form>


### PR DESCRIPTION
## Summary
- capture list of managers in UserManagement
- allow specifying manager when creating users
- show loading overlay during sign in
- disable sign-in button while loading
- prefill Settings profile fields from current user

## Testing
- `npm run lint` *(fails: 29 problems, 14 errors)*

------
https://chatgpt.com/codex/tasks/task_b_685758324d708329a6ab8a74fd374d23