### PR TITLE
Filter records by requesting user's ID

### DIFF
--- a/src/__tests__/LeadDetails.test.tsx
+++ b/src/__tests__/LeadDetails.test.tsx
@@ -13,11 +13,18 @@ vi.mock('../components/layout/DashboardLayout', () => ({
 }));
 
 vi.mock('../components/ui/select', () => {
-  const Select = ({ value, onValueChange, children, ...props }: any) => (
+  interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+    value?: string;
+    onValueChange?: (value: string) => void;
+    children?: React.ReactNode;
+  }
+  const Select = ({ value, onValueChange, children, ...props }: SelectProps) => (
     <select {...props} value={value} onChange={(e) => onValueChange?.(e.target.value)}>{children}</select>
   );
-  const Fragment = ({ children }: any) => <>{children}</>;
-  const SelectItem = ({ value, children }: any) => <option value={value}>{children}</option>;
+  const Fragment = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+  const SelectItem = ({ value, children }: { value?: string; children?: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  );
   return {
     Select,
     SelectTrigger: Fragment,

--- a/src/components/dashboard/DashboardStats.tsx
+++ b/src/components/dashboard/DashboardStats.tsx
@@ -40,12 +40,13 @@ export function StatsCard({ title, value, change, changeLabel, icon, formatter }
 }
 
 export function DashboardStats() {
-  const { fetchWithAuth } = useAuth();
+  const { fetchWithAuth, user } = useAuth();
   const [stats, setStats] = useState({ total: 0, newLeads: 0 });
 
   useEffect(() => {
     const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
-    fetchWithAuth(`${API_BASE_URL}/crm-leads`)
+    const uid = user?.userid ?? '';
+    fetchWithAuth(`${API_BASE_URL}/crm-leads?userId=${uid}`)
       .then(res => res.json())
       .then((data: { createdat?: string }[]) => {
         const total = data.length;
@@ -55,7 +56,7 @@ export function DashboardStats() {
       .catch(() => {
         setStats({ total: 0, newLeads: 0 });
       });
-  }, [fetchWithAuth]);
+  }, [fetchWithAuth, user]);
 
   const formatCurrency = (value: number | string) => {
     return new Intl.NumberFormat('en-US', {

--- a/src/pages/LeadDetails.tsx
+++ b/src/pages/LeadDetails.tsx
@@ -126,7 +126,10 @@ export default function LeadDetails() {
         }
 
         if (editMode) {
-          const leadData = await fetchWithAuth(`${API_BASE_URL}/crm-leads/${id}`).then(res => res.json());
+          const uid = user?.userid ?? '';
+          const leadData = await fetchWithAuth(
+            `${API_BASE_URL}/crm-leads/${id}?userId=${uid}`
+          ).then(res => res.json());
 
           if (leadData.assignedto) {
             const uid = Number(leadData.assignedto);
@@ -225,7 +228,10 @@ export default function LeadDetails() {
     }
 
     if (!editMode) {
-      const existing: LeadForm[] = await fetchWithAuth(`${API_BASE_URL}/crm-leads`).then(r => r.json());
+      const uid = user?.userid ?? '';
+      const existing: LeadForm[] = await fetchWithAuth(
+        `${API_BASE_URL}/crm-leads?userId=${uid}`
+      ).then(r => r.json());
       if (existing.some((l) => l.email === form.email || l.phone === form.phone || (form.legalnamessn && l.legalnamessn === form.legalnamessn) || (form.last4ssn && l.last4ssn === form.last4ssn))) {
         toast({ title: 'Duplicate lead found', variant: 'destructive' });
         return;

--- a/src/pages/Leads.tsx
+++ b/src/pages/Leads.tsx
@@ -54,6 +54,7 @@ const Leads = () => {
 
   useEffect(() => {
     setLoading(true);
+    const uid = user?.userid ?? '';
     Promise.all([
       fetchWithAuth(`${API_BASE_URL}/assignable-users`)
         .then(res => res.json())
@@ -65,7 +66,7 @@ const Leads = () => {
           });
           setUserMap(map);
         }),
-      fetchWithAuth(`${API_BASE_URL}/crm-leads`)
+      fetchWithAuth(`${API_BASE_URL}/crm-leads?userId=${uid}`)
         .then(res => res.json())
         .then((data: Lead[]) => setLeads(data))
     ]).finally(() => setLoading(false));

--- a/src/pages/UserManagement.tsx
+++ b/src/pages/UserManagement.tsx
@@ -51,8 +51,9 @@ export default function UserManagement() {
 
   useEffect(() => {
     setLoading(true);
+    const uid = user?.userid ?? '';
     Promise.all([
-      fetchWithAuth(`${API_BASE_URL}/users`)
+      fetchWithAuth(`${API_BASE_URL}/users?userId=${uid}`)
         .then(res => res.json())
         .then((data: User[]) => {
           setUsers(data);
@@ -62,7 +63,7 @@ export default function UserManagement() {
         .then(res => res.json())
         .then((data: { name: string }[]) => setRoles(data.map(r => r.name)))
     ]).finally(() => setLoading(false));
-  }, [fetchWithAuth, API_BASE_URL]);
+  }, [fetchWithAuth, API_BASE_URL, user]);
 
   const allowedRoles = roles.filter(r => {
     const id = roleIdMap[r.toLowerCase()] ?? Infinity;


### PR DESCRIPTION
## Summary
- send current user ID in API calls for leads and users

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_685844f761248329ab53478d49766907