### PR TITLE
Add test for RoleAccess and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm install
+      - run: npm run lint
+      - run: npm run test

--- a/src/__tests__/RoleAccess.test.tsx
+++ b/src/__tests__/RoleAccess.test.tsx
@@ -1,0 +1,79 @@
+import { beforeAll, afterAll, afterEach, expect, test, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import RoleAccess from '../pages/RoleAccess';
+import { AuthProvider } from '../hooks/useAuth';
+import '@testing-library/jest-dom/vitest';
+
+vi.mock('../components/layout/DashboardLayout', () => ({
+  DashboardLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../hooks/use-mobile', () => ({ useIsMobile: () => false }));
+
+const okJson = (data: unknown) =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response);
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation(() => ({
+      matches: false,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia,
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanup();
+  localStorage.clear();
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+function renderRoleAccess() {
+  localStorage.setItem(
+    'auth',
+    JSON.stringify({
+      user: { userid: 1, name: 'Tester', email: 'tester@example.com', roleid: 1 },
+      token: 'abc',
+      refreshToken: 'def',
+    }),
+  );
+  const fetchMock = vi.fn((url: RequestInfo) => {
+    const u = String(url);
+    if (u.includes('/roles')) {
+      return okJson([
+        { name: 'Super Admin' },
+        { name: 'Admin' },
+        { name: 'Manager' },
+        { name: 'Sales Lead' },
+        { name: 'Sales Agent' },
+      ]);
+    }
+    if (u.includes('/role-access')) return okJson({});
+    return okJson({});
+  });
+  vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+  return render(
+    <AuthProvider>
+      <MemoryRouter>
+        <RoleAccess />
+      </MemoryRouter>
+    </AuthProvider>,
+  );
+}
+
+test('renders headers for all roles returned from API', async () => {
+  renderRoleAccess();
+  const roles = ['Super Admin', 'Admin', 'Manager', 'Sales Lead', 'Sales Agent'];
+  for (const role of roles) {
+    expect(await screen.findByText(role)).toBeInTheDocument();
+  }
+});

--- a/src/__tests__/roleAccessUtils.test.ts
+++ b/src/__tests__/roleAccessUtils.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { hasComponentAccess } from '../lib/roleAccess';
+
+describe('hasComponentAccess', () => {
+  it('grants access when allowed entry exists', () => {
+    expect(hasComponentAccess(1, 'dashboard')).toBe(true);
+    expect(hasComponentAccess(5, 'leads')).toBe(true);
+  });
+
+  it('denies access when no entry exists', () => {
+    expect(hasComponentAccess(3, 'settings')).toBe(false);
+  });
+});

--- a/src/lib/roleAccess.ts
+++ b/src/lib/roleAccess.ts
@@ -1,0 +1,13 @@
+export const rolePermissions: Record<string, number[]> = {
+  dashboard: [1, 2, 3, 4, 5],
+  contacts: [1, 2, 3, 4, 5],
+  deals: [1, 2, 3, 4, 5],
+  leads: [1, 2, 3, 4, 5],
+  reports: [1, 2, 3, 4],
+  settings: [1, 2],
+};
+
+export function hasComponentAccess(roleId: number, componentId: string): boolean {
+  const allowed = rolePermissions[componentId];
+  return Array.isArray(allowed) ? allowed.includes(roleId) : false;
+}


### PR DESCRIPTION
## Summary
- test `RoleAccess` page for role header rendering
- add GitHub Actions workflow to run lint and tests

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_685a31bf4a008329ae09abcebd6a349b